### PR TITLE
Add space between symbol and price to show the price properly.

### DIFF
--- a/forx/convert.py
+++ b/forx/convert.py
@@ -122,7 +122,7 @@ def main():
             formatted_price = f"{price:.10f}"
             while formatted_price.endswith("0"):
                 formatted_price = formatted_price[:-1]
-        print(symbol + formatted_price)
+        print(symbol , formatted_price)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I noticed that I couldn't see the price of the money because symbol and price were too close.
Before: 
![image](https://user-images.githubusercontent.com/46342237/150645099-6be7db86-2923-43c9-bea5-d7b89ab820e8.png)
After: 
![image](https://user-images.githubusercontent.com/46342237/150645129-5c4f1f55-d581-41e4-a0b1-9ad2f6470820.png)
